### PR TITLE
Minor typo and formatting fixes to docs

### DIFF
--- a/terrainbento/base_class/erosion_model.py
+++ b/terrainbento/base_class/erosion_model.py
@@ -1,6 +1,6 @@
 # coding: utf8
 #! /usr/env/python
-"""Base class for common functions of all terrainbentoerosion models.
+"""Base class for common functions of all terrainbento erosion models.
 
 The **ErosionModel** is a base class that contains all of the functionality
 shared by the terrainbento models.
@@ -84,7 +84,7 @@ Parameters that control creation of a synthetic RasterModelGrid
 These parameters control the size, shape, and model boundary conditions of a
 synthetic ``RasterModelGrid``.  These parameters are used if neither
 ``DEM_filename`` nor ``'model_grid'`` is specified or if
-`model_grid == 'RasterModelGrid'``.
+``model_grid == 'RasterModelGrid'``.
 
 number_of_node_rows : int, optional
     Number of node rows. Default is 4.
@@ -125,7 +125,7 @@ add_noise_to_all_nodes : bool, optional
 
 Parameters that control grid boundary conditions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-terrainbentoprovides the ability for an arbitrary number of boundary
+terrainbento provides the ability for an arbitrary number of boundary
 condition handler classes to operate on the model grid each time step in order
 to handle time-variable boundary conditions such as: changing a watershed outlet
 elevation, modifying precipitation parameters through time, or simulating
@@ -163,7 +163,7 @@ feet_to_meters : boolean, optional
 
 Parameters that control surface hydrology
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-terrainbentouses the Landlab FlowAccumulator component to manage surface
+terrainbento uses the Landlab FlowAccumulator component to manage surface
 hydrology. These parameters control options associated with this component.
 
 flow_director : str, optional
@@ -255,7 +255,7 @@ class ErosionModel(object):
             Dictionary containing the input file. One of input_file or params
             is required.
         OutputWriters : class, function, or list of classes and/or functions,
-            optional Classes or functions used to write incremental output
+            Optional classes or functions used to write incremental output
             (e.g. make a diagnostic plot).
 
         Returns
@@ -441,7 +441,7 @@ class ErosionModel(object):
     def setup_boundary_handler(self, name):
         """ Setup BoundaryHandlers for use by a terrainbento model.
 
-        A boundary condition handler is a class with a run_one_step method that
+        A boundary condition handler is a class with a **run_one_step** method that
         takes the parameter ``dt``. Permitted boundary condition handlers
         include the Landlab Component ``NormalFault`` as well as the following
         options from terrainbento: **PrecipChanger**,
@@ -500,7 +500,7 @@ class ErosionModel(object):
         output, calculate a loss function, or do some other task that is not
         inherent to running a terrainbento model but is desired by the
         user. An example might be making a plot of topography while the model
-        is running. terrainbentosaves output to NetCDF format at each
+        is running. terrainbento saves output to NetCDF format at each
         interval defined by the parameter ``'output_interval'``.
 
         If a class, an OutputWriter will be instantiated with only one passed
@@ -807,7 +807,7 @@ class ErosionModel(object):
         ----------
         parameter_name : str
         raise_error : boolean
-            Raise an error if parameter doesn not exist. Default is True.
+            Raise an error if parameter does not exist. Default is True.
 
         Returns
         -------
@@ -819,7 +819,7 @@ class ErosionModel(object):
         >>> from landlab import HexModelGrid
         >>> from terrainbento import ErosionModel
 
-        Sometimes in makes sense to provide a parameter as an exponent (base 10).
+        Sometimes it makes sense to provide a parameter as an exponent (base 10).
         If the string `'_exp'` is attached to the end of the name in the input
         dictionary, this function can help.
 

--- a/terrainbento/base_class/stochastic_erosion_model.py
+++ b/terrainbento/base_class/stochastic_erosion_model.py
@@ -1,7 +1,7 @@
 # coding: utf8
 #! /usr/env/python
 """
-Base class for common functions of terrainbentostochastic erosion models.
+Base class for common functions of terrainbento stochastic erosion models.
 
 The **StochasticErosionModel** is a base class that contains all of the
 functionality shared by the terrainbento models that use stochastic
@@ -89,9 +89,9 @@ class StochasticErosionModel(ErosionModel):
     This is a base class that handles processes related to the generation of
     preciptiation events.
 
-    It is expected that a derived model will define an ``__init__`` and a
+    It is expected that a derived model will define an **__init__** and a
      **run_one_step** method. If desired, the derived model can overwrite the
-     existing ``run_for``, **run**, and **finalize** methods.
+     existing **run_for**, **run**, and **finalize** methods.
     """
 
     def __init__(self, input_file=None, params=None, OutputWriters=None):
@@ -190,12 +190,12 @@ class StochasticErosionModel(ErosionModel):
         return runoff
 
     def run_for_stochastic(self, dt, runtime):
-        """Run_for with stochastic duration.
+        """**Run_for** with stochastic duration.
 
         Run model without interruption for a specified time period, using
         random storm/interstorm sequence.
 
-        ``run_for_stochastic`` runs the model for the duration ``runtime`` with
+        **run_for_stochastic** runs the model for the duration ``runtime`` with
         model time steps given by the PrecipitationDistribution component.
         Model run steps will not exceed the duration given by ``dt``.
 

--- a/terrainbento/boundary_condition_handlers/capture_node_baselevel_handler.py
+++ b/terrainbento/boundary_condition_handlers/capture_node_baselevel_handler.py
@@ -93,7 +93,7 @@ class CaptureNodeBaselevelHandler(object):
          [ 0.  0.  0.  0.  0.]]
 
         Running forward another 10 time units, we should
-        see node three lower by 30.
+        see node 3 lower by 30.
 
         >>> for _ in range(10):
         ...     bh.run_one_step(1)
@@ -106,7 +106,7 @@ class CaptureNodeBaselevelHandler(object):
         >>> bh.model_time
         20.0
 
-        Now that model time has reached 20, lowering will occur at the post
+        Now that model time has reached 20, lowering will occur at the post-
         capture incision rate. The node should lower by 1 to -31 in the next
         10 time units.
 

--- a/terrainbento/boundary_condition_handlers/generic_function_baselevel_handler.py
+++ b/terrainbento/boundary_condition_handlers/generic_function_baselevel_handler.py
@@ -7,11 +7,11 @@ class GenericFuncBaselevelHandler(object):
     """Control the elevation of all nodes that are not core nodes.
 
     The **GenericFuncBaselevelHandler** controls the elevation of all nodes on
-    the model grid with ``status != 0`` (core nodes). The elevation change is
-    defined by a generic function of the x and y position across the grid and
-    the model time, t. Thus a user is able to use this single BaselevelHandler
-    object to make many different uplift patterns, including uplift patterns
-    that change as a function of model time.
+    the model grid with ``status != 0`` (i.e., all not-core nodes). The 
+    elevation change is defined by a generic function of the x and y position 
+    across the grid and the model time, t. Thus a user is able to use this 
+    single BaselevelHandler object to make many different uplift patterns, 
+    including uplift patterns that change as a function of model time.
 
     Through the parameter ``modify_core_nodes`` the user can determine if the
     core nodes should be moved in the direction (up or down) specified by the

--- a/terrainbento/boundary_condition_handlers/generic_function_baselevel_handler.py
+++ b/terrainbento/boundary_condition_handlers/generic_function_baselevel_handler.py
@@ -7,10 +7,10 @@ class GenericFuncBaselevelHandler(object):
     """Control the elevation of all nodes that are not core nodes.
 
     The **GenericFuncBaselevelHandler** controls the elevation of all nodes on
-    the model grid with ``status != 0`` (i.e., all not-core nodes). The 
-    elevation change is defined by a generic function of the x and y position 
-    across the grid and the model time, t. Thus a user is able to use this 
-    single BaselevelHandler object to make many different uplift patterns, 
+    the model grid with ``status != 0`` (i.e., all not-core nodes). The
+    elevation change is defined by a generic function of the x and y position
+    across the grid and the model time, t. Thus a user is able to use this
+    single BaselevelHandler object to make many different uplift patterns,
     including uplift patterns that change as a function of model time.
 
     Through the parameter ``modify_core_nodes`` the user can determine if the

--- a/terrainbento/boundary_condition_handlers/not_core_node_baselevel_handler.py
+++ b/terrainbento/boundary_condition_handlers/not_core_node_baselevel_handler.py
@@ -11,8 +11,8 @@ class NotCoreNodeBaselevelHandler(object):
     """Control the elevation of all nodes that are not core nodes.
 
     The **NotCoreNodeBaselevelHandler** controls the elevation of all nodes on
-    the model grid with ``status != 0`` (i.e., all not-core nodes). The 
-    elevation change at these nodes is specified either as a constant rate, or 
+    the model grid with ``status != 0`` (i.e., all not-core nodes). The
+    elevation change at these nodes is specified either as a constant rate, or
     through a text file that specifies the elevation change through time.
 
     Through the parameter ``modify_core_nodes`` the user can determine if the

--- a/terrainbento/boundary_condition_handlers/not_core_node_baselevel_handler.py
+++ b/terrainbento/boundary_condition_handlers/not_core_node_baselevel_handler.py
@@ -11,9 +11,9 @@ class NotCoreNodeBaselevelHandler(object):
     """Control the elevation of all nodes that are not core nodes.
 
     The **NotCoreNodeBaselevelHandler** controls the elevation of all nodes on
-    the model grid with ``status != 0`` (core nodes). The elevation change at
-    these nodes is specified either as a constant rate, or through a
-    text file that specifies the elevation change through time.
+    the model grid with ``status != 0`` (i.e., all not-core nodes). The 
+    elevation change at these nodes is specified either as a constant rate, or 
+    through a text file that specifies the elevation change through time.
 
     Through the parameter ``modify_core_nodes`` the user can determine if the
     core nodes should be moved in the direction (up or down) specified by the

--- a/terrainbento/boundary_condition_handlers/precip_changer.py
+++ b/terrainbento/boundary_condition_handlers/precip_changer.py
@@ -291,12 +291,12 @@ class PrecipChanger(object):
         Parameters
         ----------
         grid : landlab model grid
-        rainfall_intermittency_factor : float, optional
-            Starting value of the rainfall rainfall_intermittency_factor :math:`F`. This
+        daily_rainfall_intermittency_factor : float, optional
+            Starting value of the daily rainfall intermittency factor :math:`F`. This
             value is a proportion and ranges from 0 (no rain ever) to 1 (rains
             every day).
-        rainfall_intermittency_factor__time_rate_of_change : float, optional
-            Time rate of change of the rainfall rainfall_intermittency_factor :math:`F`.
+        daily_rainfall_intermittency_factor__time_rate_of_change : float, optional
+            Time rate of change of the daily rainfall intermittency factor :math:`F`.
             Units are implied by the ``time_unit`` argument. Note that this
             factor must always be between 0 and 1.
         rainfall__mean_rate : float, optional
@@ -317,7 +317,7 @@ class PrecipChanger(object):
             Model time at which changing the precipitation should start. Default
             is at the onset of the model run.
         precipchanger_stop_time : float, optional
-            Model Time at which changing the precipitation statistics should end.
+            Model time at which changing the precipitation statistics should end.
             Default is no end time.
         length_factor : float, optional
             terrainbento model internal length factor conversion related to
@@ -330,7 +330,7 @@ class PrecipChanger(object):
         ``rainfall__mean_rate_time_rate_of_change``, and
         ``infiltration_capacity`` are all assumed to be the same.
 
-        The value passed by ``time_unit`` **IS** assumed to be consistent with
+        The value passed by ``time_unit`` is assumed to be consistent with
         the time units of `dt`.
 
         The length units are assumed to be consistent with the model grid

--- a/terrainbento/boundary_condition_handlers/single_node_baselevel_handler.py
+++ b/terrainbento/boundary_condition_handlers/single_node_baselevel_handler.py
@@ -11,11 +11,11 @@ class SingleNodeBaselevelHandler(object):
 
     The **SingleNodeBaselevelHandler** controls the elevation of a single open
     boundary node, referred to here as the *outlet*. The outlet lowering rate is
-    specified either as a constant or through a time or through a text file 
+    specified either as a constant or through a time or through a text file
     that specifies the elevation change through time.
 
     The **SingleNodeBaselevelHandler** expects that ``topographic__elevation``
-    is an at-node model grid field. It will modify this field and, if it 
+    is an at-node model grid field. It will modify this field and, if it
     exists, the field ``bedrock__elevation``.
 
     Note that **SingleNodeBaselevelHandler** increments time at the end of the

--- a/terrainbento/boundary_condition_handlers/single_node_baselevel_handler.py
+++ b/terrainbento/boundary_condition_handlers/single_node_baselevel_handler.py
@@ -11,12 +11,12 @@ class SingleNodeBaselevelHandler(object):
 
     The **SingleNodeBaselevelHandler** controls the elevation of a single open
     boundary node, referred to here as the *outlet*. The outlet lowering rate is
-    specified either as a constant or through a time or through a textfile that
-    specifies the elevation change through time.
+    specified either as a constant or through a time or through a text file 
+    that specifies the elevation change through time.
 
     The **SingleNodeBaselevelHandler** expects that ``topographic__elevation``
-    is a at-node model grid field. It will modify this field and, if it exists,
-    the field ``bedrock__elevation``.
+    is an at-node model grid field. It will modify this field and, if it 
+    exists, the field ``bedrock__elevation``.
 
     Note that **SingleNodeBaselevelHandler** increments time at the end of the
     **run_one_step** method.

--- a/terrainbento/derived_models/model_018_basicDdHy.py
+++ b/terrainbento/derived_models/model_018_basicDdHy.py
@@ -36,9 +36,8 @@ class BasicDdHy(ErosionModel):
     :math:`K` is the erodability by water, :math:`\omega_{ct}` is the critical
     stream power needed for erosion to occur, :math:`V` is effective sediment
     settling velocity, :math:`Q_s` is volumetric sediment flux, :math:`Q` is
-    volumetric water discharge, :math:`\phi` is sediment porosity, :math:`D` is
-    the regolith transport efficiency, :math:`H` is soil depth, and :math:`H_*`
-    is the bedrock roughness length scale,
+    volumetric water discharge, :math:`\phi` is sediment porosity,  and
+    :math:`D` is the regolith transport efficiency.
 
     :math:`\omega_{ct}` may change through time as it increases with cumulative
     incision depth:

--- a/terrainbento/derived_models/model_040_basicCh.py
+++ b/terrainbento/derived_models/model_040_basicCh.py
@@ -37,7 +37,7 @@ class BasicCh(ErosionModel):
     where :math:`A` is the local drainage area, :math:`S` is the local slope,
     :math:`m` and :math:`n` are the drainage area and slope exponent parameters,
     :math:`K` is the erodability by water, :math:`D` is the regolith
-    transport efficiency, and :math:`S_c` is the critical slope. :math:`q_s`
+    transport efficiency, and :math:`S_c` is the critical slope. :math:`q_h`
     represents the hillslope sediment flux per unit width. :math:`N` is the
     number of terms in the Taylor Expansion and is set at 11.
 

--- a/terrainbento/derived_models/model_100_basicSt.py
+++ b/terrainbento/derived_models/model_100_basicSt.py
@@ -34,8 +34,8 @@ class BasicSt(StochasticErosionModel):
 
     where :math:`\hat{Q}` is the local stream discharge (the hat symbol
     indicates that it is a random-in-time variable), :math:`S` is the local
-    slope gradient, :math:`m` and :math:`n` are the discharge and slope 
-    exponents, respectively, and :math:`D` is the regolith transport parameter. 
+    slope gradient, :math:`m` and :math:`n` are the discharge and slope
+    exponents, respectively, and :math:`D` is the regolith transport parameter.
 
     **BasicSt** inherits from the terrainbento **StochasticErosionModel** base
     class. In addition to the parameters required by the base class, models
@@ -74,14 +74,14 @@ class BasicSt(StochasticErosionModel):
     overriding the run_for method.
 
     If the user does not request stochastic duration (indicated by setting
-    ``opt_stochastic_duration`` to ``False``), then the default 
-    (**erosion_model** base class) **run_for** method is used. Whenever 
-    **run_one_step** is called, storm intensity is generated at random from an 
-    exponential distribution with mean given by the parameter 
-    ``rainfall__mean_rate``. The stream power component is run for only a 
+    ``opt_stochastic_duration`` to ``False``), then the default
+    (**erosion_model** base class) **run_for** method is used. Whenever
+    **run_one_step** is called, storm intensity is generated at random from an
+    exponential distribution with mean given by the parameter
+    ``rainfall__mean_rate``. The stream power component is run for only a
     fraction of the time step duration dt, as specified by the parameter
-    ``rainfall_intermittency_factor``. For example, if ``dt`` is 10 years and 
-    the intermittency factor is 0.25, then the stream power component is run 
+    ``rainfall_intermittency_factor``. For example, if ``dt`` is 10 years and
+    the intermittency factor is 0.25, then the stream power component is run
     for only 2.5 years.
 
     In either case, given a storm precipitation intensity :math:`P`, the runoff
@@ -94,7 +94,7 @@ class BasicSt(StochasticErosionModel):
     infiltration capacity is assumed to have an exponential distribution of which
     $I$ is the mean. Hence, there are always some spots within any given grid cell
     that will generate runoff. This approach yields a smooth transition from
-    near-zero runoff (when :math:`I>>P`) to :math:`R \\approx P` 
+    near-zero runoff (when :math:`I>>P`) to :math:`R \\approx P`
     (when :math`P>>I`), without a "hard threshold."
 
     """

--- a/terrainbento/derived_models/model_100_basicSt.py
+++ b/terrainbento/derived_models/model_100_basicSt.py
@@ -33,9 +33,9 @@ class BasicSt(StochasticErosionModel):
         \\frac{\partial \eta}{\partial t} = -K_{q}\hat{Q}^{m}S^{n} + D\\nabla^2 \eta
 
     where :math:`\hat{Q}` is the local stream discharge (the hat symbol
-    indicates that it is a random-in-time variable) and :math:`S` is the local
-    slope gradient. Refer to the terrainbento manuscript Table XX (URL here)
-    for parameter symbols, names, and dimensions.
+    indicates that it is a random-in-time variable), :math:`S` is the local
+    slope gradient, :math:`m` and :math:`n` are the discharge and slope 
+    exponents, respectively, and :math:`D` is the regolith transport parameter. 
 
     **BasicSt** inherits from the terrainbento **StochasticErosionModel** base
     class. In addition to the parameters required by the base class, models
@@ -58,7 +58,7 @@ class BasicSt(StochasticErosionModel):
     Refer to the terrainbento manuscript Table XX (URL here) for full list of
     parameter symbols, names, and dimensions.
 
-    Model BasicSt models discharge and erosion across a topographic
+    Model **BasicSt** models discharge and erosion across a topographic
     surface assuming (1) stochastic Poisson storm arrivals, (2) single-direction
     flow routing, and (3) Hortonian infiltration model. Includes stream-power
     erosion plus linear diffusion.
@@ -74,14 +74,15 @@ class BasicSt(StochasticErosionModel):
     overriding the run_for method.
 
     If the user does not request stochastic duration (indicated by setting
-    opt_stochastic_duration to False), then the default (erosion_model base class)
-    run_for method is used. Whenever run_one_step is called, storm intensity is
-    generated at random from an exponential distribution with mean given by the
-    parameter rainfall__mean_rate. The stream power component is run for
-    only a fraction of the time step duration dt, as specified by the parameter
-    rainfall_intermittency_factor. For example, if dt is 10 years and the
-    intermittency factor is 0.25, then the stream power component is run for only
-    2.5 years.
+    ``opt_stochastic_duration`` to ``False``), then the default 
+    (**erosion_model** base class) **run_for** method is used. Whenever 
+    **run_one_step** is called, storm intensity is generated at random from an 
+    exponential distribution with mean given by the parameter 
+    ``rainfall__mean_rate``. The stream power component is run for only a 
+    fraction of the time step duration dt, as specified by the parameter
+    ``rainfall_intermittency_factor``. For example, if ``dt`` is 10 years and 
+    the intermittency factor is 0.25, then the stream power component is run 
+    for only 2.5 years.
 
     In either case, given a storm precipitation intensity :math:`P`, the runoff
     production rate :math:`R` [L/T] is calculated using:
@@ -93,8 +94,8 @@ class BasicSt(StochasticErosionModel):
     infiltration capacity is assumed to have an exponential distribution of which
     $I$ is the mean. Hence, there are always some spots within any given grid cell
     that will generate runoff. This approach yields a smooth transition from
-    near-zero runoff (when :math:`I>>P`) to :math:`R \approx P` (when :math`P>>I`),
-    without a "hard threshold."
+    near-zero runoff (when :math:`I>>P`) to :math:`R \\approx P` 
+    (when :math`P>>I`), without a "hard threshold."
 
     """
 

--- a/terrainbento/derived_models/model_102_basicStTh.py
+++ b/terrainbento/derived_models/model_102_basicStTh.py
@@ -27,7 +27,7 @@ class BasicStTh(StochasticErosionModel):
 
     **BasicStTh** is a model program that uses a stochastic treatment of runoff
     and discharge, and includes an erosion threshold in the water erosion law.
-    THe model evolves a topographic surface, :math:`\eta (x,y,t)`,
+    The model evolves a topographic surface, :math:`\eta (x,y,t)`,
     with the following governing equation:
 
     .. math::
@@ -36,7 +36,10 @@ class BasicStTh(StochasticErosionModel):
 
     where :math:`\hat{Q}` is the local stream discharge (the hat symbol
     indicates that it is a random-in-time variable) and :math:`S` is the local
-    slope gradient. Refer to the terrainbento manuscript Table XX (URL here)
+    slope gradient. :math:`m` and :math:`n` are the discharge and slope
+    exponent, respectively, :math:`\omega_c` is the critical stream power
+    required for erosion to occur, and :math:`D` is the regolith transport
+    parameter. Refer to the terrainbento manuscript Table XX (URL here)
     for parameter symbols, names, and dimensions.
 
     **BasicSt** inherits from the terrainbento **StochasticErosionModel** base

--- a/terrainbento/derived_models/model_108_basicDdSt.py
+++ b/terrainbento/derived_models/model_108_basicDdSt.py
@@ -36,14 +36,31 @@ class BasicDdSt(StochasticErosionModel):
 
     .. math::
 
-        \\frac{\partial \eta}{\partial t} = -[K_{q}\hat{Q}^{m}S^{n} - \omega_c(x, y, t)] + D\\nabla^2 \eta
+        \\frac{\partial \eta}{\partial t} = -[K_{q}\hat{Q}^{m}S^{n} - \omega_{ct}\left(1-e^{-K_{q}\hat{Q}^{m}S^{n}/\omega_{ct}}\\right)\\right)] + D\\nabla^2 \eta
 
     where :math:`\hat{Q}` is the local stream discharge (the hat symbol
     indicates that it is a random-in-time variable) and :math:`S` is the local
-    slope gradient. Refer to the terrainbento manuscript Table XX (URL here)
+    slope gradient. :math:`m` and :math:`n` are the discharge and slope
+    exponent, respectively, :math:`\omega_c` is the critical stream power
+    required for erosion to occur, and :math:`D` is the regolith transport
+    parameter.
+    
+        :math:`\omega_{ct}` may change through time as it increases with cumulative
+    incision depth:
+
+    .. math::
+
+        \omega_{ct}\left(x,y,t\\right) = \mathrm{max}\left(\omega_c + b D_I\left(x, y, t\\right), \omega_c \\right)
+
+    where :math:`\omega_c` is the threshold when no incision has taken place,
+    :math:`b` is the rate at which the threshold increases with incision depth,
+    and :math:`D_I` is the cumulative incision depth at location
+    :math:`\left(x,y\\right)` and time :math:`t`.
+    
+    Refer to the terrainbento manuscript Table XX (URL here)
     for parameter symbols, names, and dimensions.
 
-    **BasicSt** inherits from the terrainbento **StochasticErosionModel** base
+    **BasicDdSt** inherits from the terrainbento **StochasticErosionModel** base
     class. In addition to the parameters required by the base class, models
     built with this program require the following parameters:
 

--- a/terrainbento/derived_models/model_110_basicHySt.py
+++ b/terrainbento/derived_models/model_110_basicHySt.py
@@ -36,9 +36,10 @@ class BasicHySt(StochasticErosionModel):
         \\frac{\partial \eta}{\partial t} = -E(\hat{Q}) + D_s(\hat{Q}) + D\\nabla^2 \eta
 
     where :math:`\hat{Q}` is the local stream discharge (the hat symbol
-    indicates that it is a random-in-time variable), $E$ is the bed erosion
-    (entrainment) rate due to fluid entrainment, and $D_s$ is the deposition
-    rate of sediment settling out of active transport. Refer to the terrainbento
+    indicates that it is a random-in-time variable), :math:`E` is the bed erosion
+    (entrainment) rate due to fluid entrainment, :math:`D_s` is the deposition
+    rate of sediment settling out of active transport, and :math:`D` is the
+    regolith transport parameter. Refer to the terrainbento
     manuscript Table XX (URL here) for parameter symbols, names, and
     dimensions.
 

--- a/terrainbento/derived_models/model_202_basicThVs.py
+++ b/terrainbento/derived_models/model_202_basicThVs.py
@@ -28,16 +28,8 @@ class BasicThVs(ErosionModel):
 
         \\frac{\partial \eta}{\partial t} = -\left(K A_{eff}^{m}S^{n} - \omega_{c}\left(1-e^{-KA_{eff}^{m}S^{n}/\omega_{c}}\\right)\\right) + D\\nabla^2 \eta
 
-    where:
-        
-    .. math::
-        
         A_{eff} = A \exp \left( -\\frac{-\\alpha S}{A}\\right)
 
-    and:
-        
-    .. math::
-        
         \\alpha = \\frac{K_{sat}  H_{init}  dx}{R_m}
 
 

--- a/terrainbento/derived_models/model_202_basicThVs.py
+++ b/terrainbento/derived_models/model_202_basicThVs.py
@@ -26,7 +26,7 @@ class BasicThVs(ErosionModel):
 
     .. math::
 
-        \\frac{\partial \eta}{\partial t} = -\left(K A_{eff}^{m}S^{n} - \omega_c\left(1-e^{-K_A_{eff}^{m}S^{n}/\omega_c}\\right)\\right) + D\\nabla^2 \eta
+        \\frac{\partial \eta}{\partial t} = -\left(K A_{eff}^{m}S^{n} - \omega_{c}\left(1-e^{-KA_{eff}^{m}S^{n}/\omega_{c}}\\right)\\right) + D\\nabla^2 \eta
 
     where:
         

--- a/terrainbento/derived_models/model_202_basicThVs.py
+++ b/terrainbento/derived_models/model_202_basicThVs.py
@@ -24,13 +24,20 @@ class BasicThVs(ErosionModel):
     **BasicThVs** is a model program that evolves a topographic surface described
     by :math:`\eta` with the following governing equations:
 
-
     .. math::
 
         \\frac{\partial \eta}{\partial t} = -\left(K A_{eff}^{m}S^{n} - \omega_c\left(1-e^{-K_A_{eff}^{m}S^{n}/\omega_c}\\right)\\right) + D\\nabla^2 \eta
 
+    where:
+        
+    .. math::
+        
         A_{eff} = A \exp \left( -\\frac{-\\alpha S}{A}\\right)
 
+    and:
+        
+    .. math::
+        
         \\alpha = \\frac{K_{sat}  H_{init}  dx}{R_m}
 
 
@@ -139,7 +146,7 @@ class BasicThVs(ErosionModel):
         )
 
         if float(self.params["n_sp"]) != 1.0:
-            raise ValueError("Model BasicThVs only supports n = 1.")
+            raise ValueError("Model BasicThVs only supports n = 1.")
 
         self.m = self.params["m_sp"]
         self.n = self.params["n_sp"]

--- a/terrainbento/derived_models/model_210_basicHyVs.py
+++ b/terrainbento/derived_models/model_210_basicHyVs.py
@@ -40,9 +40,8 @@ class BasicHyVs(ErosionModel):
     :math:`K` is the erodability by water, :math:`\omega_c` is the critical
     stream power needed for erosion to occur, :math:`V` is effective sediment
     settling velocity, :math:`Q_s` is volumetric sediment flux, :math:`Q` is
-    volumetric water discharge, :math:`\phi` is sediment porosity, :math:`D` is
-    the regolith transport efficiency, :math:`H` is soil depth, and :math:`H_*`
-    is the bedrock roughness length scale.
+    volumetric water discharge, :math:`\phi` is sediment porosity, and
+    :math:`D` is the regolith transport efficiency.
 
     :math:`\\alpha` is the saturation area scale used for transforming area into
     effective area :math:`A_{eff}`. It is given as a function of the saturated

--- a/terrainbento/derived_models/model_400_basicSa.py
+++ b/terrainbento/derived_models/model_400_basicSa.py
@@ -50,7 +50,7 @@ class BasicSa(ErosionModel):
     where :math:`A` is the local drainage area, :math:`S` is the local slope,
     :math:`m` and :math:`n` are the drainage area and slope exponent parameters,
     :math:`K` is the erodability by water, :math:`D` is the regolith transport
-    parameter, :math:`H_s` is the sediment production decay depth, :math:`H_s`
+    parameter, :math:`H` is the regolith thickness, :math:`H_s`
     is the sediment production decay depth, :math:`P_0` is the maximum sediment
     production rate, and :math:`H_0` is the sediment transport decay depth. :math:`q_s`
     represents the hillslope sediment flux per unit width.

--- a/terrainbento/derived_models/model_410_basicHySa.py
+++ b/terrainbento/derived_models/model_410_basicHySa.py
@@ -38,8 +38,7 @@ class BasicHySa(ErosionModel):
     respectively, :math:`A` is the local drainage area, :math:`S` is the local
     slope, :math:`m` and :math:`n` are the drainage area and slope exponent
     parameters, :math:`H` is soil depth, :math:`H_*` is the bedrock roughness
-    length scale, :math:`\omega_c` is the critical stream power needed for
-    erosion to occur, :math:`V` is effective sediment settling velocity,
+    length scale, :math:`V` is effective sediment settling velocity,
     :math:`Q_s` is volumetric fluvial sediment flux, :math:`Q` is volumetric
     water discharge, and :math:`\phi` is sediment porosity. Hillslope sediment
     flux per unit width :math:`q_h` is given by:

--- a/terrainbento/derived_models/model_440_basicChSa.py
+++ b/terrainbento/derived_models/model_440_basicChSa.py
@@ -29,11 +29,11 @@ class BasicChSa(ErosionModel):
     """ **BasicChSa** model program.
 
 
-    **BasicSa** is a model program that explicitly resolves a soil layer. This
+    **BasicChSa** is a model program that explicitly resolves a soil layer. This
     soil layer is produced by weathering that decays exponentially with soil
     thickness and hillslope transport is soil-depth dependent. Given a spatially
     varying soil thickness :math:`H` and a spatially varying bedrock elevation
-    :math:`\eta_b`, model **BasicSa** evolves a topographic surface described by
+    :math:`\eta_b`, model **BasicChSa** evolves a topographic surface described by
     :math:`\eta` with the following governing equations:
 
     .. math::
@@ -52,7 +52,7 @@ class BasicChSa(ErosionModel):
     parameter, :math:`H_s` is the sediment production decay depth, :math:`H_s`
     is the sediment production decay depth, :math:`P_0` is the maximum sediment
     production rate, and :math:`H_0` is the sediment transport decay depth.
-    :math:`q_s` represents the hillslope sediment flux per unit width. :math:`S_c`
+    :math:`q_h` is the hillslope sediment flux per unit width. :math:`S_c`
     is the critical slope parameter and :math:`N` is the number of terms in the
     Taylor Series expansion. Presently :math:`N` is set at 11 and is not a user
     defined parameter.

--- a/terrainbento/derived_models/model_600_basicSaVs.py
+++ b/terrainbento/derived_models/model_600_basicSaVs.py
@@ -25,10 +25,11 @@ from terrainbento.base_class import ErosionModel
 
 
 class BasicSaVs(ErosionModel):
-    """**BasicVs** model program.
+    """**BasicSaVs** model program.
 
-    **BasicVs** is a model program that evolves a topographic surface described
-    by :math:`\eta` with the following governing equations:
+    Given a spatially varying soil thickness :math:`H` and a spatially varying
+    bedrock elevation :math:`\eta_b`, model **BasicSaVs** evolves a topographic
+    surface described by :math:`\eta` with the following governing equations:
 
 
     .. math::
@@ -51,7 +52,7 @@ class BasicSaVs(ErosionModel):
     :math:`K` is the erodability by water, :math:`D` is the regolith transport
     parameter :math:`H_s` is the sediment production decay depth, :math:`H_s`
     is the sediment production decay depth, :math:`P_0` is the maximum sediment
-    production rate, and :math:`H_0` is the sediment transport decay depth. :math:`q_s`
+    production rate, and :math:`H_0` is the sediment transport decay depth. :math:`q_h`
     represents the hillslope sediment flux per unit width.
 
     :math:`\\alpha` is the saturation area scale used for transforming area into
@@ -59,7 +60,7 @@ class BasicSaVs(ErosionModel):
     hydraulic conductivity :math:`K_{sat}`, the soil thickness :math:`H_{init}`,
     the grid spacing :math:`dx`, and the recharge rate, :math:`R_m`.
 
-    The **BasicVs** program inherits from the terrainbento **ErosionModel** base
+    The **BasicSaVs** program inherits from the terrainbento **ErosionModel** base
     class. In addition to the parameters required by the base class, models
     built with this program require the following parameters.
 

--- a/terrainbento/derived_models/model_600_basicSaVs.py
+++ b/terrainbento/derived_models/model_600_basicSaVs.py
@@ -50,10 +50,10 @@ class BasicSaVs(ErosionModel):
     where :math:`A` is the local drainage area, :math:`S` is the local slope,
     :math:`m` and :math:`n` are the drainage area and slope exponent parameters,
     :math:`K` is the erodability by water, :math:`D` is the regolith transport
-    parameter :math:`H_s` is the sediment production decay depth, :math:`H_s`
-    is the sediment production decay depth, :math:`P_0` is the maximum sediment
-    production rate, and :math:`H_0` is the sediment transport decay depth. :math:`q_h`
-    represents the hillslope sediment flux per unit width.
+    parameter, :math:`H_s` is the sediment production decay depth, :math:`H_0`
+    is the sediment transport decay depth, :math:`P_0` is the maximum sediment
+    production rate, and :math:`H_0` is the sediment transport decay depth.
+    :math:`q_h` is the hillslope sediment flux per unit width.
 
     :math:`\\alpha` is the saturation area scale used for transforming area into
     effective area :math:`A_{eff}`. It is given as a function of the saturated

--- a/terrainbento/derived_models/model_810_basicHyRt.py
+++ b/terrainbento/derived_models/model_810_basicHyRt.py
@@ -32,9 +32,9 @@ class BasicHyRt(TwoLithologyErosionModel):
 
     .. math::
 
-        \\frac{\partial \eta}{\partial t} = \\frac{V Q_s}{A} - K A^{m}S^{n} + D\\nabla^2 \eta
+        \\frac{\partial \eta}{\partial t} = \\frac{V Q_s}{Q} - K A^{m}S^{n} + D\\nabla^2 \eta
 
-        Q_s = \int_0^A \left(KA^{m}S^{n} - \\frac{V Q_s}{A} \\right) dA
+        Q_s = \int_0^A \left(KA^{m}S^{n} - \\frac{V Q_s}{Q} \\right) dA
 
         K(\eta, \eta_C ) = w K_1 + (1 - w) K_2
 
@@ -46,10 +46,10 @@ class BasicHyRt(TwoLithologyErosionModel):
     :math:`W_c` is the contact-zone width, :math:`K_1` and :math:`K_2` are the
     erodabilities of the upper and lower lithologies, and :math:`D` is the
     regolith transport parameter. :math:`Q_s` is the volumetric sediment
-    discharge and :math:`V` is the effective settling velocity of the sediment
-    :math:`w` is a weight used to calculate the effective erodability
-    :math:`K(\eta, \eta_C)` based on the depth to the contact zone and the width
-    of the contact zone.
+    discharge, :math:`Q` is the volumetric water discharge, and :math:`V` is
+    the effective settling velocity of the sediment. :math:`w` is a weight used
+    to calculate the effective erodability :math:`K(\eta, \eta_C)` based on the
+    depth to the contact zone and the width of the contact zone.
 
     The weight :math:`w` promotes smoothness in the solution of erodability at a
     given point. When the surface elevation is at the contact elevation, the

--- a/terrainbento/derived_models/model_842_basicChRtTh.py
+++ b/terrainbento/derived_models/model_842_basicChRtTh.py
@@ -51,8 +51,11 @@ class BasicChRtTh(TwoLithologyErosionModel):
     erodabilities of the upper and lower lithologies, and :math:`D` is the
     regolith transport parameter. :math:`w` is a weight used to calculate the
     effective erodability :math:`K(\eta, \eta_C)` based on the depth to the
-    contact zone and the width of the contact zone. Refer to the terrainbento
-    manuscript Table XX (URL here) for parameter symbols, names, and dimensions.
+    contact zone and the width of the contact zone. :math:`N` is the number of
+    terms in the Taylor Series expansion. Presently :math:`N` is set at 11 and
+    is not a user defined parameter. Refer to the terrainbento manuscript
+    Table XX (URL here) for parameter symbols, names, and dimensions.
+    
 
     The weight :math:`w` promotes smoothness in the solution of erodability at a
     given point. When the surface elevation is at the contact elevation, the

--- a/terrainbento/derived_models/model_C00_basicRtSa.py
+++ b/terrainbento/derived_models/model_C00_basicRtSa.py
@@ -59,7 +59,11 @@ class BasicRtSa(TwoLithologyErosionModel):
     erodabilities of the upper and lower lithologies, and :math:`D` is the
     regolith transport parameter. :math:`w` is a weight used to calculate the
     effective erodability :math:`K(\eta, \eta_C)` based on the depth to the
-    contact zone and the width of the contact zone.
+    contact zone and the width of the contact zone. :math:`H_s` is the sediment
+    production decay depth, :math:`H_0` is the sediment transport decay depth,
+    :math:`P_0` is the maximum sediment production rate, and :math:`H_0` is the
+    sediment transport decay depth. :math:`q_h` is the hillslope sediment flux
+    per unit width.
 
     The function :math:`\delta (H)` is used to indicate that water erosion will
     act on soil where it exists, and on the underlying lithology where soil is

--- a/terrainbento/derived_models/model_CCC_basicCv.py
+++ b/terrainbento/derived_models/model_CCC_basicCv.py
@@ -31,9 +31,10 @@ class BasicCv(ErosionModel):
         \\frac{\partial \eta}{\partial t} = -KA^{m}S^{n} + D\\nabla^2 \eta
 
 
-    where :math:`A` is the local drainage area, :math:`S` is the local slope,
-    and :math:`m` and :math:`n` are the drainage area and slope exponent
-    parameters.
+    where :math:`K` is the fluviel erodability coefficient, :math:`A` is the 
+    local drainage area, :math:`S` is the local slope, :math:`m` and :math:`n` 
+    are the drainage area and slope exponent parameters, and :math:`D` is the 
+    regolith transport parameter.
 
     This model also has a basic parameterization of climate change such that
     :math:`K` varies through time. Between model run onset and a time at

--- a/terrainbento/derived_models/model_CCC_basicCv.py
+++ b/terrainbento/derived_models/model_CCC_basicCv.py
@@ -31,9 +31,9 @@ class BasicCv(ErosionModel):
         \\frac{\partial \eta}{\partial t} = -KA^{m}S^{n} + D\\nabla^2 \eta
 
 
-    where :math:`K` is the fluviel erodability coefficient, :math:`A` is the 
-    local drainage area, :math:`S` is the local slope, :math:`m` and :math:`n` 
-    are the drainage area and slope exponent parameters, and :math:`D` is the 
+    where :math:`K` is the fluviel erodability coefficient, :math:`A` is the
+    local drainage area, :math:`S` is the local slope, :math:`m` and :math:`n`
+    are the drainage area and slope exponent parameters, and :math:`D` is the
     regolith transport parameter.
 
     This model also has a basic parameterization of climate change such that


### PR DESCRIPTION
I went through and fixed many small things like typos and variable definitions and equation formatting. Not suggesting that everything is perfect, but I'm comfortable submitting to GMD with the docs in this form. I found one issue where a table wasn't rendering (#98) which I can't figure out how to fix. @kbarnhart merge whenever tests pass and you feel is convenient.