### PR TITLE
fixing a few typos

### DIFF
--- a/terrainbento/base_class/erosion_model.py
+++ b/terrainbento/base_class/erosion_model.py
@@ -325,7 +325,7 @@ class ErosionModel(object):
 
             If the default values of both the precipitator and
             runoff_generator are used, then :math:`Q` will be equal to drainage
-            area. XXXX might acknowledge that Kq = K R**m  and with R=1...
+            area.
 
         flow_director : str, optional
             String name of a

--- a/terrainbento/base_class/stochastic_erosion_model.py
+++ b/terrainbento/base_class/stochastic_erosion_model.py
@@ -49,7 +49,7 @@ class StochasticErosionModel(ErosionModel):
     ``rainfall__shape_factor`` and with a scale factor calculated so that the
     mean of the distribution has the value given by ``rainfall__mean_rate``.
 
-    The following parameter are used:
+    The following parameters are used:
 
         - rainfall__shape_factor
         - number_of_sub_time_steps
@@ -58,7 +58,7 @@ class StochasticErosionModel(ErosionModel):
 
     The hydrology uses calculation of drainage area using the user-specified
     routing method. It then performs one of two options, depending on the
-    user"s choice of ``opt_stochastic_duration`` (True or False).
+    user's choice of ``opt_stochastic_duration`` (True or False).
 
     If the user requests stochastic duration, the model iterates through a sequence
     of storm and interstorm periods. Storm depth is drawn at random from a gamma
@@ -89,7 +89,7 @@ class StochasticErosionModel(ErosionModel):
     :math:`I` is the mean. Hence, there are always some spots within any given grid cell
     that will generate runoff. This approach yields a smooth transition from
     near-zero runoff (when :math:`I>>P`) to :math:`R \\approx P`
-    (when :math`P>>I`), without a "hard threshold."
+    (when :math:`P>>I`), without a "hard threshold."
 
     The following at-node fields must be specified in the grid:
         - ``topographic__elevation``
@@ -317,7 +317,7 @@ class StochasticErosionModel(ErosionModel):
         have been calculated already. It might be zero, in which case we
         are between storms, so we don't do water erosion.
 
-        If we're NOT doing stochastic duration, then we"ll run water
+        If we're NOT doing stochastic duration, then we'll run water
         erosion for one or more sub-time steps, each with its own
         randomly drawn precipitation intensity.
 

--- a/terrainbento/precipitators/random_precipitation.py
+++ b/terrainbento/precipitators/random_precipitation.py
@@ -9,7 +9,7 @@ class RandomPrecipitator(object):
     **RandomPrecipitator** populates the at-node field "rainfall__flux" with
     random values drawn from a distribution. All distributions provided in the
     `numpy.random submodule
-    <https://docs.scipy.org/doc/numpy-1.15.1/reference/routines.random.html#distributions>`_.
+    <https://docs.scipy.org/doc/numpy-1.15.1/reference/routines.random.html#distributions>`_
     are supported.
 
     Examples

--- a/terrainbento/precipitators/random_precipitation.py
+++ b/terrainbento/precipitators/random_precipitation.py
@@ -9,7 +9,7 @@ class RandomPrecipitator(object):
     **RandomPrecipitator** populates the at-node field "rainfall__flux" with
     random values drawn from a distribution. All distributions provided in the
     `numpy.random submodule
-    <https://docs.scipy.org/doc/numpy-1.15.1/reference/routines.random.html#distributions>`
+    <https://docs.scipy.org/doc/numpy-1.15.1/reference/routines.random.html#distributions>`_.
     are supported.
 
     Examples

--- a/terrainbento/precipitators/random_precipitation.py
+++ b/terrainbento/precipitators/random_precipitation.py
@@ -9,7 +9,7 @@ class RandomPrecipitator(object):
     **RandomPrecipitator** populates the at-node field "rainfall__flux" with
     random values drawn from a distribution. All distributions provided in the
     `numpy.random submodule
-    <https://docs.scipy.org/doc/numpy-1.15.1/reference/routines.random.html#distributions>`_.
+    <https://docs.scipy.org/doc/numpy-1.15.1/reference/routines.random.html#distributions>`
     are supported.
 
     Examples


### PR DESCRIPTION
A couple typos fixed in:

*ErosionModel
*StochasticErosionModel
*RandomPrecipitator

edit: not totally sure if the change to RandomPrecipitator (removing _.) is kosher, but the way it looked had the link acting all weird in the docs.